### PR TITLE
Added UDTs parsing support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,55 @@ async def execute(scylla: Scylla) -> None:
     )
 ```
 
+## User defined types
+
+We also support user defined types. You can pass them as a parameter to query.
+Or parse it as a model in response.
+
+Here's binding example. Imagine we have defined a type in scylla like this:
+
+```cql
+CREATE TYPE IF NOT EXISTS test (
+    id int,
+    name text
+);
+```
+
+Now we need to define a model for it in python.
+
+```python
+from dataclasses import dataclass
+from scyllapy.extra_types import ScyllaPyUDT
+
+@dataclass
+class TestUDT(ScyllaPyUDT):
+    # Always define fields in the same order as in scylla.
+    # Otherwise you will get an error, or wrong data.
+    id: int
+    name: str
+
+async def execute(scylla: Scylla) -> None:
+    await scylla.execute(
+        "INSERT INTO table(id, udt_col) VALUES (?, ?)",
+        [1, TestUDT(id=1, name="test")],
+    )
+
+```
+
+We also support pydantic based models. Decalre them like this:
+
+```python
+from pydantic import BaseModel
+from scyllapy.extra_types import ScyllaPyUDT
+
+
+class TestUDT(BaseModel, ScyllaPyUDT):
+    # Always define fields in the same order as in scylla.
+    # Otherwise you will get an error, or wrong data.
+    id: int
+    name: str
+
+```
 
 # Query building
 

--- a/python/scyllapy/extra_types.py
+++ b/python/scyllapy/extra_types.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any
+from typing import Any, List
 
 from ._internal.extra_types import BigInt, Counter, Double, SmallInt, TinyInt, Unset
 
@@ -19,7 +19,7 @@ class ScyllaPyUDT:
     It can be further extended to support other model types.
     """
 
-    def __dump_udt__(self) -> list[Any]:
+    def __dump_udt__(self) -> List[Any]:
         """
         Method to dump UDT models to a dict.
 

--- a/python/scyllapy/extra_types.py
+++ b/python/scyllapy/extra_types.py
@@ -1,3 +1,48 @@
+import dataclasses
+from typing import Any
+
 from ._internal.extra_types import BigInt, Counter, Double, SmallInt, TinyInt, Unset
 
-__all__ = ("BigInt", "Counter", "Double", "SmallInt", "TinyInt", "Unset")
+try:
+    import pydantic
+except ImportError:
+    pydantic = None
+
+
+class ScyllaPyUDT:
+    """
+    Class for declaring UDT models.
+
+    This class is a mixin for models like dataclasses and pydantic models,
+    or classes that have `__slots__` attribute.
+
+    It can be further extended to support other model types.
+    """
+
+    def __dump_udt__(self) -> list[Any]:
+        """
+        Method to dump UDT models to a dict.
+
+        This method returns a list of values in the order of the UDT fields.
+        Because in the protocol, UDT fields should be sent in the same order as
+        they were declared.
+        """
+        if dataclasses.is_dataclass(self):
+            values = []
+            for field in dataclasses.fields(self):
+                values.append(getattr(self, field.name))
+            return values
+        if pydantic is not None and isinstance(self, pydantic.BaseModel):
+            values = []
+            for param in self.__class__.__signature__.parameters:
+                values.append(getattr(self, param))
+            return values
+        if hasattr(self, "__slots__"):
+            values = []
+            for slot in self.__slots__:
+                values.append(getattr(self, slot))
+            return values
+        raise ValueError("Unsupported model type")
+
+
+__all__ = ("BigInt", "Counter", "Double", "SmallInt", "TinyInt", "Unset", "ScyllaPyUDT")

--- a/python/tests/test_extra_types.py
+++ b/python/tests/test_extra_types.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict, dataclass
 from typing import Any
 
 import pytest
@@ -69,3 +70,61 @@ async def test_unset(scylla: Scylla) -> None:
         f"INSERT INTO {table_name}(id, name) VALUES (?, ?)",
         [1, extra_types.Unset()],
     )
+
+
+@pytest.mark.anyio
+async def test_udts(scylla: Scylla) -> None:
+    @dataclass
+    class TestUDT(extra_types.ScyllaPyUDT):
+        id: int
+        name: str
+
+    table_name = random_string(4)
+
+    udt_val = TestUDT(id=1, name="test")
+    await scylla.execute(f"CREATE TYPE test_udt{table_name} (id int, name text)")
+    await scylla.execute(
+        f"CREATE TABLE {table_name} "
+        f"(id INT PRIMARY KEY, udt_col frozen<test_udt{table_name}>)",
+    )
+    await scylla.execute(
+        f"INSERT INTO {table_name} (id, udt_col) VALUES (?, ?)",
+        [1, udt_val],
+    )
+
+    res = await scylla.execute(f"SELECT * FROM {table_name}")
+    assert res.all() == [{"id": 1, "udt_col": asdict(udt_val)}]
+
+
+@pytest.mark.anyio
+async def test_nested_udts(scylla: Scylla) -> None:
+    @dataclass
+    class NestedUDT(extra_types.ScyllaPyUDT):
+        one: int
+        two: str
+
+    @dataclass
+    class TestUDT(extra_types.ScyllaPyUDT):
+        id: int
+        name: str
+        nested: NestedUDT
+
+    table_name = random_string(4)
+
+    udt_val = TestUDT(id=1, name="test", nested=NestedUDT(one=1, two="2"))
+    await scylla.execute(f"CREATE TYPE nested_udt{table_name} (one int, two text)")
+    await scylla.execute(
+        f"CREATE TYPE test_udt{table_name} "
+        f"(id int, name text, nested frozen<nested_udt{table_name}>)",
+    )
+    await scylla.execute(
+        f"CREATE TABLE {table_name} "
+        f"(id INT PRIMARY KEY, udt_col frozen<test_udt{table_name}>)",
+    )
+    await scylla.execute(
+        f"INSERT INTO {table_name} (id, udt_col) VALUES (?, ?)",
+        [1, udt_val],
+    )
+
+    res = await scylla.execute(f"SELECT * FROM {table_name}")
+    assert res.all() == [{"id": 1, "udt_col": asdict(udt_val)}]

--- a/python/tests/test_parsing.py
+++ b/python/tests/test_parsing.py
@@ -1,0 +1,19 @@
+import pytest
+from tests.utils import random_string
+
+from scyllapy import Scylla
+
+
+@pytest.mark.anyio
+async def test_udt_parsing(scylla: Scylla) -> None:
+    table_name = random_string(4)
+    await scylla.execute(f"CREATE TYPE test_udt{table_name} (id int, name text)")
+    await scylla.execute(
+        f"CREATE TABLE {table_name} "
+        f"(id int PRIMARY KEY, udt_col frozen<test_udt{table_name}>)",
+    )
+    await scylla.execute(
+        f"INSERT INTO {table_name} (id, udt_col) VALUES (1, {{id: 1, name: 'test'}})",
+    )
+    res = await scylla.execute(f"SELECT * FROM {table_name}")
+    assert res.all() == [{"id": 1, "udt_col": {"id": 1, "name": "test"}}]

--- a/python/tests/test_queries.py
+++ b/python/tests/test_queries.py
@@ -28,3 +28,34 @@ async def test_as_class(scylla: Scylla) -> None:
     res = await scylla.execute(f"SELECT id FROM {table_name}")
 
     assert res.all(as_class=TestDTO) == [TestDTO(id=42)]
+
+
+@pytest.mark.anyio
+async def test_udt_as_dataclass(scylla: Scylla) -> None:
+    @dataclass
+    class UDTType:
+        id: int
+        name: str
+
+    @dataclass
+    class TestDTO:
+        id: int
+        udt_col: UDTType
+
+        def __post_init__(self) -> None:
+            if not isinstance(self.udt_col, UDTType):
+                self.udt_col = UDTType(**self.udt_col)
+
+    table_name = random_string(4)
+    await scylla.execute(f"CREATE TYPE test_udt{table_name} (id int, name text)")
+    await scylla.execute(
+        f"CREATE TABLE {table_name} "
+        f"(id int PRIMARY KEY, udt_col frozen<test_udt{table_name}>)",
+    )
+    await scylla.execute(
+        f"INSERT INTO {table_name} (id, udt_col) VALUES (1, {{id: 1, name: 'test'}})",
+    )
+    res = await scylla.execute(f"SELECT * FROM {table_name}")
+    assert res.all(as_class=TestDTO) == [
+        TestDTO(id=1, udt_col=UDTType(id=1, name="test")),
+    ]

--- a/src/exceptions/rust_err.rs
+++ b/src/exceptions/rust_err.rs
@@ -44,6 +44,8 @@ pub enum ScyllaPyError {
     RowsDowncastError(String),
     #[error("Cannot parse value of column {0} as {1}.")]
     ValueDowncastError(String, &'static str),
+    #[error("Cannot downcast UDT {0} of column {1}. Reason: {2}.")]
+    UDTDowncastError(String, String, String),
     #[error("Query didn't suppose to return anything.")]
     NoReturnsError,
     #[error("Query doesn't have columns.")]
@@ -73,6 +75,7 @@ impl From<ScyllaPyError> for pyo3::PyErr {
             | ScyllaPyError::IpParseError(_) => ScyllaPyBindingError::new_err((err_desc,)),
             ScyllaPyError::RowsDowncastError(_)
             | ScyllaPyError::ValueDowncastError(_, _)
+            | ScyllaPyError::UDTDowncastError(_, _, _)
             | ScyllaPyError::NoReturnsError
             | ScyllaPyError::NoColumns => ScyllaPyMappingError::new_err((err_desc,)),
             ScyllaPyError::QueryBuilderError(_) => ScyllaPyQueryBuiderError::new_err((err_desc,)),


### PR DESCRIPTION
This PR adds support for UDTs as requested in #34. 

- [x] Add support for parsing UDT fields from scylla response
- ~~[ ] Add support for registering UDTs~~ Because we don't need to be able to define them. Only binding and parsing.
- [x] Add support for binding UDTs
- [x] Add support for nested UDTs
- [x] Update docs
