### PR TITLE
Fix prepared statement tests and map type handling

### DIFF
--- a/python/tests/test_prepared.py
+++ b/python/tests/test_prepared.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable
+
 import pytest
 from tests.utils import random_string
 
@@ -16,3 +18,38 @@ async def test_prepared(scylla: Scylla) -> None:
     prepared_res = await scylla.execute(prepared)
 
     assert res.all() == prepared_res.all()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("type_name", "test_val", "cast_func"),
+    [
+        ("SET<TEXT>", ["one", "two"], set),
+        ("SET<TEXT>", {"one", "two"}, set),
+        ("SET<TEXT>", ("one", "two"), set),
+        ("LIST<TEXT>", ("1", "2"), list),
+        ("LIST<TEXT>", ["1", "2"], list),
+        ("LIST<TEXT>", {"1", "2"}, list),
+        ("MAP<TEXT, TEXT>", {"one": "two"}, dict),
+        ("MAP<INT, BIGINT>", {1: 2}, dict),
+    ],
+)
+async def test_prepared_collections(
+    scylla: Scylla,
+    type_name: str,
+    test_val: Any,
+    cast_func: Callable[[Any], Any],
+) -> None:
+    table_name = random_string(4)
+    await scylla.execute(
+        f"CREATE TABLE {table_name} (id INT, coll {type_name}, PRIMARY KEY (id))",
+    )
+
+    insert_query = f"INSERT INTO {table_name}(id, coll) VALUES (?, ?)"
+    prepared = await scylla.prepare(insert_query)
+    await scylla.execute(prepared, [1, test_val])
+
+    result = await scylla.execute(f"SELECT * FROM {table_name}")
+    rows = result.all()
+    assert len(rows) == 1
+    assert rows[0] == {"id": 1, "coll": cast_func(test_val)}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -276,10 +276,17 @@ pub fn py_to_value(
             let item_tuple = dict_item.downcast::<PyTuple>().map_err(|err| {
                 ScyllaPyError::BindingError(format!("Cannot cast to tuple: {err}"))
             })?;
-            items.push((
-                py_to_value(item_tuple.get_item(0)?, column_type)?,
-                py_to_value(item_tuple.get_item(1)?, column_type)?,
-            ));
+            if let Some(ColumnType::Map(key_type, val_type)) = column_type {
+                items.push((
+                    py_to_value(item_tuple.get_item(0)?, Some(key_type.as_ref()))?,
+                    py_to_value(item_tuple.get_item(1)?, Some(val_type.as_ref()))?,
+                ));
+            } else {
+                items.push((
+                    py_to_value(item_tuple.get_item(0)?, column_type)?,
+                    py_to_value(item_tuple.get_item(1)?, column_type)?,
+                ));
+            }
         }
         Ok(ScyllaPyCQLDTO::Map(items))
     } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -169,14 +169,22 @@ pub fn py_to_value(
             Some(ColumnType::SmallInt) => Ok(ScyllaPyCQLDTO::SmallInt(item.extract::<i16>()?)),
             Some(ColumnType::BigInt) => Ok(ScyllaPyCQLDTO::BigInt(item.extract::<i64>()?)),
             Some(ColumnType::Counter) => Ok(ScyllaPyCQLDTO::Counter(item.extract::<i64>()?)),
-            Some(_) | None => Ok(ScyllaPyCQLDTO::Int(item.extract::<i32>()?)),
+            Some(ColumnType::Int) | None => Ok(ScyllaPyCQLDTO::Int(item.extract::<i32>()?)),
+            Some(_) => Err(ScyllaPyError::BindingError(format!(
+                "Unsupported type for parameter binding: {column_type:?}"
+            ))),
         }
     } else if item.is_instance_of::<PyFloat>() {
         match column_type {
             Some(ColumnType::Double) => Ok(ScyllaPyCQLDTO::Double(eq_float::F64(
                 item.extract::<f64>()?,
             ))),
-            Some(_) | None => Ok(ScyllaPyCQLDTO::Float(eq_float::F32(item.extract::<f32>()?))),
+            Some(ColumnType::Float) | None => {
+                Ok(ScyllaPyCQLDTO::Float(eq_float::F32(item.extract::<f32>()?)))
+            }
+            Some(_) => Err(ScyllaPyError::BindingError(format!(
+                "Unsupported type for parameter binding: {column_type:?}"
+            ))),
         }
     } else if item.is_instance_of::<SmallInt>() {
         Ok(ScyllaPyCQLDTO::SmallInt(


### PR DESCRIPTION
I experienced some issues regarding type marshaling of maps, such as `map<int, bigint`:
```
scyllapy.exceptions.ScyllaPyDBError: Database returned an error: The query is syntactically correct but invalid, Error message: Exception while binding column permissions: marshaling error: Validation failed for type org.apache.cassandra.db.marshal.LongType: got 4 bytes
```
After digging through the code, I identified the issue: If `column_type` is a `Map`—such as `Map(Int, BigInt)` in this case—the `PyDict` case of `py_to_value` would pass along `ColumnType::Map` to as the column_type to the recursive call, and since default match in the `PyInt` case was int32, it would incorrectly pass an int32 to a bigint field.

To make issues like these simpler to debug in the future, I also refactored the `PyInt` and `PyFloat` cases not to choose an implicit default but instead return a `BindingError` if an unsupported type were to be bound.