### PR TITLE
Added more TLS options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,3 +481,4 @@ To make built `Select` query return paginated iterator, add paged parameter in e
     async for row in rows:
         print(row['id'])
 ```
+

--- a/python/scyllapy/__init__.py
+++ b/python/scyllapy/__init__.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version
 
+from . import extra_types
 from ._internal import (
     Batch,
     BatchType,
@@ -11,6 +12,7 @@ from ._internal import (
     QueryResult,
     Scylla,
     SerialConsistency,
+    SSLVerifyMode,
 )
 
 __version__ = version("scyllapy")
@@ -25,6 +27,7 @@ __all__ = [
     "Batch",
     "BatchType",
     "QueryResult",
+    "SSLVerifyMode",
     "extra_types",
     "InlineBatch",
     "ExecutionProfile",

--- a/python/scyllapy/_internal/__init__.pyi
+++ b/python/scyllapy/_internal/__init__.pyi
@@ -14,6 +14,18 @@ from scyllapy._internal.load_balancing import LoadBalancingPolicy
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2")
 
+class SSLVerifyMode:
+    """
+    SSL Verify modes.
+
+    Used for SSL/TLS connection verification.
+    Read mode: https://docs.rs/openssl/0.10.68/openssl/ssl/struct.SslVerifyMode.html
+    """
+
+    NONE: SSLVerifyMode
+    PEER: SSLVerifyMode
+    FAIL_IF_NO_PEER_CERT: SSLVerifyMode
+
 class Scylla:
     """
     Scylla class.
@@ -32,6 +44,9 @@ class Scylla:
         password: str | None = None,
         keyspace: str | None = None,
         ssl_cert: str | None = None,
+        ssl_key: str | None = None,
+        ssl_ca_file: str | None = None,
+        ssl_verify_mode: SSLVerifyMode | None = None,
         conn_timeout: int | None = None,
         write_coalescing: bool | None = None,
         pool_size_per_host: int | None = None,
@@ -50,8 +65,13 @@ class Scylla:
             ["192.168.1.1:9042", "my_keyspace.node:9042"]
         :param username: Plain text auth username.
         :param password: Plain text auth password.
-        :param ssl_cert: Certficiate string to use
-            for connection. AWS requires it.
+        :param ssl_cert: Certficiate string to use for connection.
+            Should be PEM encoded x509 certificate string.
+        :param ssl_key: Key string to use for connection.
+            Should be RSA private key PEM encoded string.
+        :param ssl_ca_file: CA file to use for connection. This parameter
+            should be a path to the CA file (which is PEM encoded CA).
+        :param ssl_verify_mode: tells server on how to validate client's certificate.
         :param conn_timeout: Timeout in seconds.
         :param write_coalescing:
             If true, the driver will inject a small delay before flushing data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use crate::utils::add_submodule;
 fn _internal(py: Python<'_>, pymod: &PyModule) -> PyResult<()> {
     pyo3_log::init();
     pymod.add_class::<scylla_cls::Scylla>()?;
+    pymod.add_class::<scylla_cls::ScyllaPySSLVerifyMode>()?;
     pymod.add_class::<consistencies::ScyllaPyConsistency>()?;
     pymod.add_class::<consistencies::ScyllaPySerialConsistency>()?;
     pymod.add_class::<queries::ScyllaPyQuery>()?;


### PR DESCRIPTION
Added more SSL/TLS options. Now it's possible to set CertificateAuthority file, private RSA key file and SslVerificationMode. 

All these parameters can be used together to connect to scylla using self-signed certificates. 