### PR TITLE
Request_timeout to f64

### DIFF
--- a/python/scyllapy/_internal/__init__.pyi
+++ b/python/scyllapy/_internal/__init__.pyi
@@ -157,7 +157,7 @@ class ExecutionProfile:
         *,
         consistency: Consistency | None = None,
         serial_consistency: SerialConsistency | None = None,
-        request_timeout: int | None = None,
+        request_timeout: float | None = None,
         load_balancing_policy: LoadBalancingPolicy | None = None,
     ) -> None: ...
 
@@ -197,7 +197,7 @@ class Query:
     query: str
     consistency: Consistency | None
     serial_consistency: SerialConsistency | None
-    request_timeout: int | None
+    request_timeout: float | None
     is_idempotent: bool | None
     tracing: bool | None
     profile: ExecutionProfile
@@ -207,7 +207,7 @@ class Query:
         query: str,
         consistency: Consistency | None = None,
         serial_consistency: SerialConsistency | None = None,
-        request_timeout: int | None = None,
+        request_timeout: float | None = None,
         timestamp: int | None = None,
         is_idempotent: bool | None = None,
         tracing: bool | None = None,
@@ -218,7 +218,7 @@ class Query:
         self,
         serial_consistency: SerialConsistency | None,
     ) -> Query: ...
-    def with_request_timeout(self, request_timeout: int | None) -> Query: ...
+    def with_request_timeout(self, request_timeout: float | None) -> Query: ...
     def with_timestamp(self, timestamp: int | None) -> Query: ...
     def with_is_idempotent(self, is_idempotent: bool | None) -> Query: ...
     def with_tracing(self, tracing: bool | None) -> Query: ...
@@ -239,7 +239,7 @@ class Batch:
         batch_type: BatchType = ...,
         consistency: Consistency | None = None,
         serial_consistency: SerialConsistency | None = None,
-        request_timeout: int | None = None,
+        request_timeout: float | None = None,
         timestamp: int | None = None,
         is_idempotent: bool | None = None,
         tracing: bool | None = None,
@@ -252,7 +252,7 @@ class InlineBatch:
         batch_type: BatchType = ...,
         consistency: Consistency | None = None,
         serial_consistency: SerialConsistency | None = None,
-        request_timeout: int | None = None,
+        request_timeout: float | None = None,
         timestamp: int | None = None,
         is_idempotent: bool | None = None,
         tracing: bool | None = None,

--- a/src/execution_profiles.rs
+++ b/src/execution_profiles.rs
@@ -26,7 +26,7 @@ impl ScyllaPyExecutionProfile {
     fn py_new(
         consistency: Option<ScyllaPyConsistency>,
         serial_consistency: Option<ScyllaPySerialConsistency>,
-        request_timeout: Option<u64>,
+        request_timeout: Option<f64>,
         load_balancing_policy: Option<ScyllaPyLoadBalancingPolicy>,
     ) -> Self {
         let mut profile_builder = scylla::ExecutionProfile::builder();
@@ -38,7 +38,7 @@ impl ScyllaPyExecutionProfile {
         }
         profile_builder = profile_builder
             .serial_consistency(serial_consistency.map(SerialConsistency::from))
-            .request_timeout(request_timeout.map(Duration::from_secs));
+            .request_timeout(request_timeout.map(Duration::from_secs_f64));
         Self {
             inner: profile_builder.build(),
         }

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -12,7 +12,7 @@ use scylla::{batch::Batch, execution_profile::ExecutionProfileHandle, statement:
 pub struct ScyllaPyRequestParams {
     pub consistency: Option<ScyllaPyConsistency>,
     pub serial_consistency: Option<ScyllaPySerialConsistency>,
-    pub request_timeout: Option<u64>,
+    pub request_timeout: Option<f64>,
     pub timestamp: Option<i64>,
     pub is_idempotent: Option<bool>,
     pub tracing: Option<bool>,
@@ -33,7 +33,7 @@ impl ScyllaPyRequestParams {
         }
         query.set_execution_profile_handle(self.profile.as_ref().map(ExecutionProfileHandle::from));
         query.set_timestamp(self.timestamp);
-        query.set_request_timeout(self.request_timeout.map(Duration::from_secs));
+        query.set_request_timeout(self.request_timeout.map(Duration::from_secs_f64));
         query.set_serial_consistency(self.serial_consistency.map(Into::into));
     }
 
@@ -153,7 +153,7 @@ impl ScyllaPyQuery {
     }
 
     #[must_use]
-    pub fn with_request_timeout(&self, request_timeout: Option<u64>) -> Self {
+    pub fn with_request_timeout(&self, request_timeout: Option<f64>) -> Self {
         let mut query = Self::from(self);
         query.params.request_timeout = request_timeout;
         query


### PR DESCRIPTION
## Request_timeout to f64

Following [this](https://www.reddit.com/r/FastAPI/comments/1inwccg/comment/mcjlb28/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) conversation on reddit, this PR updates the `request_timeout` parameter to `f64`, allowing for sub-second timeouts (e.g., `0.25` seconds). 


---

Let me know if there's any feedback or direction you'd like me to take with this.
